### PR TITLE
Ensure EV Plug instructions and links all works

### DIFF
--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -150,7 +150,7 @@ const loadIcons = (): void => {
 
         const icon: IconType = {
             name: iconKey,
-            iconFontKey: iconDetails.name,
+            iconFontKey: iconDetails.filename.slice(0, -4),
             type: 'Filled',
             isMaterial: false,
             tags: iconDetails.tags || [],

--- a/src/app/components/icons/IconDrawer.tsx
+++ b/src/app/components/icons/IconDrawer.tsx
@@ -24,7 +24,7 @@ import { EmptyState, Spacer } from '@brightlayer-ui/react-components';
 import { GetApp, Close } from '@material-ui/icons';
 import { Pxblue } from '@brightlayer-ui/icons-mui';
 
-import { unCamelCase } from '../../shared';
+import { snakeToTitleCase } from '../../shared';
 import { emptyIcon } from '.';
 import { downloadPng, downloadSvg } from './utilityFunctions';
 
@@ -93,6 +93,7 @@ export const IconDrawer: React.FC = () => {
     const sm = useMediaQuery(theme.breakpoints.down('sm'));
     const themeConfig = getScheduledSiteConfig();
     const showBanner = useSelector((state: AppState) => state.app.showBanner);
+    const iconTitle = snakeToTitleCase(selectedIcon.iconFontKey);
 
     const closeDrawer = (): void => {
         history.replace(`${location.pathname}`);
@@ -156,10 +157,10 @@ export const IconDrawer: React.FC = () => {
                             <selectedIcon.Icon style={{ fontSize: 40 }} />
                             <div className={classes.iconNameRowDescription}>
                                 <div className={classes.iconNameWrapper}>
-                                    <Typography variant={'body1'}>{unCamelCase(selectedIcon.name)}</Typography>
+                                    <Typography variant={'body1'}>{iconTitle}</Typography>
                                     <CopyToClipboard
                                         title={'Copy Icon Name'}
-                                        copyText={unCamelCase(selectedIcon.name)}
+                                        copyText={iconTitle}
                                         style={{ marginLeft: theme.spacing(1) }}
                                     />
                                 </div>

--- a/src/app/components/icons/IconGrid.tsx
+++ b/src/app/components/icons/IconGrid.tsx
@@ -3,7 +3,7 @@ import { Grid, makeStyles, Theme, Typography } from '@material-ui/core';
 import clsx from 'clsx';
 import color from 'color';
 import { IconType } from '../../../__types__';
-import { unCamelCase } from '../../shared';
+import { snakeToTitleCase } from '../../shared';
 import { useSelectedIcon } from '../../contexts/selectedIconContextProvider';
 
 type IconGridProps = {
@@ -47,7 +47,7 @@ const Icons: React.FC<IconGridProps> = (props) => {
                 .map((icon) => {
                     const isSelected =
                         selected && selected.name === icon.name && selected.isMaterial === icon.isMaterial;
-                    const iconDisplayName = unCamelCase(icon.name);
+                    const iconDisplayName = snakeToTitleCase(icon.iconFontKey);
                     return (
                         <Grid
                             item

--- a/src/app/components/icons/utilityFunctions.tsx
+++ b/src/app/components/icons/utilityFunctions.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IconColor, IconSize, IconType } from '../../../__types__';
 import { getSvg } from '../../api';
-import { capitalize, getSnakeCase, snakeToKebabCase } from '../../shared';
+import { getSnakeCase, snakeToKebabCase } from '../../shared';
 import * as Colors from '@brightlayer-ui/colors';
 
 export type Framework = 'angular' | 'react' | 'react-native';
@@ -69,17 +69,16 @@ export const createDownloadSvgElement = (icon: IconType, iconData: string, color
     const iconUrl = `data:text/plain;charset=utf-8, ${encodeURIComponent(
         changeSvgColorAndSize(iconData, color, size)
     )}`;
-    const iconName = [icon.name, capitalize(color), '_', size, 'dp'].join('');
-    createDownloadElement(iconUrl, `${getSnakeCase(iconName).toLowerCase()}.svg`);
+    createDownloadElement(iconUrl, `${icon.iconFontKey}.svg`);
 };
 
-export const createDownloadPxbPngElement = async (
+export const createDownloadBluiPngElement = async (
     iconName: string,
     colorName: string,
     size: IconSize
 ): Promise<void> => {
-    const formattedIconName = `${getSnakeCase(iconName)}_${colorName}_${size}dp.png`;
-    const iconSrc = `https://raw.githubusercontent.com/brightlayer-ui/icons/dev/png/png${size}/${formattedIconName}`;
+    const formattedIconName = `${iconName}_${colorName}_${size}dp.png`;
+    const iconSrc = `https://raw.githubusercontent.com/brightlayer-ui/icons/master/png/png${size}/${formattedIconName}`;
     const icon = await fetch(iconSrc);
     const iconBlog = await icon.blob();
     const iconUrl = URL.createObjectURL(iconBlog);
@@ -98,7 +97,7 @@ export const downloadSvg = async (icon: IconType, color: IconColor, size: IconSi
         const iconData = (await getSvg(getSnakeCase(icon.name), 'material')) || '';
         createDownloadSvgElement(icon, iconData, color, size);
     } else {
-        const iconData = (await getSvg(getSnakeCase(icon.name), 'brightlayer-ui')) || '';
+        const iconData = (await getSvg(icon.iconFontKey, 'brightlayer-ui')) || '';
         createDownloadSvgElement(icon, iconData, color, size);
     }
 };
@@ -108,7 +107,7 @@ export const downloadPng = (icon: IconType, color: IconColor, size: IconSize): v
         createDownloadMaterialPngElement(icon.iconFontKey, color, size);
     } else {
         const colorName = color === 'white' ? `${color}50` : `${color}500`;
-        void createDownloadPxbPngElement(icon.name, colorName, size);
+        void createDownloadBluiPngElement(icon.iconFontKey, colorName, size);
     }
 };
 
@@ -120,10 +119,10 @@ export const getIconFontCopyText: GetCopyTextFn = (framework, icon) => {
             if (icon.isMaterial) {
                 return `import Icon from '@material-ui/core/Icon';\n<Icon>${icon.iconFontKey}</Icon>`;
             }
-            return `<i className="blui-${getSnakeCase(icon.name)}"></i>`;
+            return `<i className="blui-${icon.iconFontKey}"></i>`;
         case 'angular':
             if (icon.isMaterial) return `<span class="material-icons">${icon.iconFontKey}</span>`;
-            return `<i class="blui-${getSnakeCase(icon.name)}"></i>`;
+            return `<i class="blui-${icon.iconFontKey}"></i>`;
         default:
             return '';
     }
@@ -141,12 +140,12 @@ export const getIconFontSnippet: GetSnippetFn = (framework, icon) => {
                             {`<Icon>${icon.iconFontKey}</Icon>`}
                         </>
                     )}
-                    {!icon.isMaterial && `<i className="blui-${getSnakeCase(icon.name)}"></i>`}
+                    {!icon.isMaterial && `<i className="blui-${icon.iconFontKey}"></i>`}
                 </>
             );
         case 'angular':
             if (icon.isMaterial) return <>{`<span class="material-icons">${icon.iconFontKey}</span>`}</>;
-            return <>{`<i class="blui-${getSnakeCase(icon.name)}"></i>`}</>;
+            return <>{`<i class="blui-${icon.iconFontKey}"></i>`}</>;
         default:
             return <></>;
     }
@@ -158,23 +157,21 @@ export const getIconSvgCopyText: GetCopyTextFn = (framework, icon) => {
             if (icon.isMaterial) {
                 return `import ${icon.name}Icon from '@material-ui/icons/${icon.name}';\n<${icon.name}Icon></${icon.name}Icon>`;
             }
-            return `import ${getMuiIconName(icon.name)} from '@brightlayer-ui/icons-svg/${getSnakeCase(
-                icon.name
-            )}.svg';\n<img src={${getMuiIconName(icon.name)}} />`;
+            return `import ${getMuiIconName(icon.name)} from '@brightlayer-ui/icons-svg/${
+                icon.iconFontKey
+            }.svg';\n<img src={${getMuiIconName(icon.name)}} />`;
         case 'angular':
             if (icon.isMaterial) {
                 return `<mat-icon>${icon.iconFontKey}</mat-icon>`;
             }
-            return `<mat-icon svgIcon="px-icons:${getSnakeCase(icon.name)}"></mat-icon>`;
+            return `<mat-icon svgIcon="blui-icons:${icon.iconFontKey}"></mat-icon>`;
         case 'react-native':
             if (icon.isMaterial) {
                 return `import MatIcon from 'react-native-vector-icons/MaterialIcons';\n<MatIcon name="${snakeToKebabCase(
                     icon.iconFontKey
                 )}"/>;`;
             }
-            return `import BLUIIcon from '@brightlayer-ui/react-native-vector-icons';\n<BLUIIcon name="${getSnakeCase(
-                icon.name
-            )}"/>;`;
+            return `import BLUIIcon from '@brightlayer-ui/react-native-vector-icons';\n<BLUIIcon name="${icon.iconFontKey}"/>;`;
         default:
             return '';
     }
@@ -187,9 +184,9 @@ export const getIconSvgSnippet: GetSnippetFn = (framework, icon) => {
                 <>
                     {!icon.isMaterial && (
                         <>
-                            {`import ${getMuiIconName(icon.name)} from '@brightlayer-ui/icons-svg/${getSnakeCase(
-                                icon.name
-                            )}.svg';`}
+                            {`import ${getMuiIconName(icon.name)} from '@brightlayer-ui/icons-svg/${
+                                icon.iconFontKey
+                            }.svg';`}
                             <br />
                             {`<img src={${getMuiIconName(icon.name)}} />`}
                         </>
@@ -200,7 +197,7 @@ export const getIconSvgSnippet: GetSnippetFn = (framework, icon) => {
             return (
                 <>
                     {icon.isMaterial && `<mat-icon>${icon.iconFontKey}</mat-icon>`}
-                    {!icon.isMaterial && `<mat-icon svgIcon="px-icons:${getSnakeCase(icon.name)}"></mat-icon>`}
+                    {!icon.isMaterial && `<mat-icon svgIcon="blui-icons:${icon.iconFontKey}"></mat-icon>`}
                 </>
             );
         case 'react-native':
@@ -217,7 +214,7 @@ export const getIconSvgSnippet: GetSnippetFn = (framework, icon) => {
                         <>
                             {`import BLUIIcon from '@brightlayer-ui/react-native-vector-icons';`}
                             <br />
-                            {`<BLUIIcon name="${getSnakeCase(icon.name)}"/>`}
+                            {`<BLUIIcon name="${icon.iconFontKey}"/>`}
                         </>
                     )}
                 </>

--- a/src/app/shared/utilities.tsx
+++ b/src/app/shared/utilities.tsx
@@ -1,6 +1,6 @@
-export const getSnakeCase = (str: string): string => str.replace(/[A-Z]/g, '_$&').toLowerCase().substr(1);
+export const getSnakeCase = (str: string): string => str.replace(/[A-Z]/g, '_$&').toLowerCase().slice(1);
 
-export const getKebabCase = (str: string): string => str.replace(/[A-Z]/g, '-$&').toLowerCase().substr(1);
+export const getKebabCase = (str: string): string => str.replace(/[A-Z]/g, '-$&').toLowerCase().slice(1);
 
 export const snakeToKebabCase = (str: string): string => str.replaceAll('_', '-').toLowerCase();
 
@@ -12,9 +12,12 @@ export const unCamelCase = (val: string): string =>
         .replace(/^./, (str) => str.toUpperCase());
 
 export const titleCase = (val: string): string =>
-    val.replace('-', ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+    val.replace('-', ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
 
-export const capitalize = (val: string): string => val.charAt(0).toUpperCase() + val.substr(1);
+export const snakeToTitleCase = (str: string): string =>
+    str.replaceAll('_', ' ').replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase());
+
+export const capitalize = (val: string): string => val.charAt(0).toUpperCase() + val.slice(1);
 
 // https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
 function fallbackCopyTextToClipboard(text: string): void {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #486

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fixed EV Plug code snippet
- Ensure that EV Plug icons SVG and PNGs can both download properly
- Fixed a few places that still has traces of pxblue

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

![image](https://user-images.githubusercontent.com/8997218/148453877-874bfe8b-c784-4595-94c7-c1673f0023e0.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Verify that the four EV plugs mentioned in the bug report now have correct usage instructions
- Verify that the copy button for those code snippets copy correctly
- Verify that the Icon Drawer display the icon title correctly
- Verify that everything downloads and opens correctly. (Icons with wrong names can still be downloaded, but the file is corrupted and won't open)
- Verify that other regular icons (both blui icons and Material icons) are left untouched
