### PR TITLE
Bump CURRENT_RELEASE to R23

### DIFF
--- a/src/__configuration__/roadmap/index.ts
+++ b/src/__configuration__/roadmap/index.ts
@@ -10,7 +10,7 @@ export const AVAILABLE_RELEASES: Array<{
     {
         name: 'R24',
         year: 2022,
-        quarter: 'Q1',
+        quarter: 'Q2',
     },
     {
         name: 'R23',

--- a/src/__configuration__/roadmap/index.ts
+++ b/src/__configuration__/roadmap/index.ts
@@ -1,12 +1,17 @@
 import { Quarter, Release } from '../../__types__';
 
-export const CURRENT_RELEASE: Release = 'R22';
+export const CURRENT_RELEASE: Release = 'R23';
 
 export const AVAILABLE_RELEASES: Array<{
     name: Release;
     year: number;
     quarter: Quarter;
 }> = [
+    {
+        name: 'R24',
+        year: 2022,
+        quarter: 'Q1',
+    },
     {
         name: 'R23',
         year: 2022,

--- a/src/__types__/index.ts
+++ b/src/__types__/index.ts
@@ -31,7 +31,7 @@ export type IconColor = 'black' | 'blue' | 'gray' | 'white';
 export type ItemTypeFilter = 'all' | 'design' | 'development';
 export type Status = 'backlog' | 'in-progress' | 'pre-release' | 'deferred' | 'finished';
 export type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4';
-export type Release = 'R16' | 'R17' | 'R18' | 'R19' | 'R20' | 'R21' | 'R22' | 'R23';
+export type Release = 'R16' | 'R17' | 'R18' | 'R19' | 'R20' | 'R21' | 'R22' | 'R23' | 'R24';
 
 export type RoadmapItem = {
     name: string;


### PR DESCRIPTION
So that docit displays the roadmap in https://github.com/brightlayer-ui/blui-database/pull/6 