### PR TITLE
Feature/2794 hide eaton logo

### DIFF
--- a/src/app/components/icons/IconBrowser.tsx
+++ b/src/app/components/icons/IconBrowser.tsx
@@ -164,9 +164,11 @@ const loadIcons = (): void => {
 
         // add the icon details to the categorized icon list
         for (let cat of iconDetails.family) {
-            cat = cat.toLocaleLowerCase();
-            if (allIconsByCategory[cat]) allIconsByCategory[cat].push(icon);
-            else allIconsByCategory[cat] = [icon];
+            if (!iconDetails.filename.toLocaleLowerCase().includes('eaton')) {
+                cat = cat.toLocaleLowerCase();
+                if (allIconsByCategory[cat]) allIconsByCategory[cat].push(icon);
+                else allIconsByCategory[cat] = [icon];
+            }
         }
 
         // return the icon

--- a/src/docs/development/testing.mdx
+++ b/src/docs/development/testing.mdx
@@ -54,7 +54,7 @@ Angular, React, and React Native all come with built-in unit testing frameworks.
 
 ### Angular
 
-The Angular CLI comes pre-configured with [Jasmine](https://jasmine.github.io/2.0/introduction) and [Karma](https://karma-runner.github.io/latest/index.html) for unit testing. When you create a new project, sample tests are created in your project for you (test files are identified by the `.spec.ts` file extension). You can execute the tests by running the following in your terminal:
+The Angular CLI comes pre-configured with [Jasmine](https://jasmine.github.io/pages/getting_started.html) and [Karma](https://karma-runner.github.io/latest/index.html) for unit testing. When you create a new project, sample tests are created in your project for you (test files are identified by the `.spec.ts` file extension). You can execute the tests by running the following in your terminal:
 
 ```sh
 cd your/project/root


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes 2794 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Hide Eaton logo from icon library page. 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="817" alt="Screenshot 2022-01-31 at 4 09 50 PM" src="https://user-images.githubusercontent.com/10433274/151790372-eb1f8c04-4977-447d-a894-4ca691f359df.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
Search `Eaton` it should hide logos.
Deep links are working:
- http://localhost:3000/style/iconography?icon=Eaton&isMaterial=false
- http://localhost:3000/style/iconography?icon=EatonTagline&isMaterial=false
- http://localhost:3000/style/iconography?icon=EatonTwoTone&isMaterial=false
