### PR TITLE
Remove extra slash

### DIFF
--- a/src/__configuration__/navigationMenu/navigation.tsx
+++ b/src/__configuration__/navigationMenu/navigation.tsx
@@ -293,7 +293,7 @@ export const pageDefinitions: SimpleNavItem[] = [
         pages: [
             {
                 title: 'App Logos',
-                url: '/logo',
+                url: 'logo',
                 component: <MarkdownPage title={'App Logos'} markdown={Docs.Style.Logo} />,
             },
             {


### PR DESCRIPTION
There's an extra slash in the "App Logo" page's URL

## Before
![image](https://user-images.githubusercontent.com/8997218/209181221-c856342b-e84a-4b0b-85c7-af2d383514c2.png)

## After
![image](https://user-images.githubusercontent.com/8997218/209181420-6904351d-6822-46d4-80c7-252bfdc95eae.png)
